### PR TITLE
Add visual LTFS schema snapshot viewer

### DIFF
--- a/gui/DriveSlot.cs
+++ b/gui/DriveSlot.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Globalization;
 using LTOG.Gui.Core;
 using Microsoft.UI.Xaml;
 
@@ -16,6 +17,141 @@ public sealed class SchemaItem
     public string Uuid { get; set; } = "";         // volume UUID (ties snapshot to cartridge)
     public string Path { get; set; } = "";         // snapshot file on disk
     public DateTime Captured { get; set; }         // snapshot file write time (for sorting)
+}
+
+/// <summary>Parsed LTFS index snapshot used by the visual browser.</summary>
+public sealed class SchemaSnapshot
+{
+    public string Path { get; init; } = "";
+    public string FileName { get; init; } = "";
+    public string VolumeName { get; set; } = "(unlabelled volume)";
+    public string FormatVersion { get; set; } = "";
+    public string Creator { get; set; } = "";
+    public string VolumeUuid { get; set; } = "";
+    public string GenerationNumber { get; set; } = "?";
+    public string UpdatedText { get; set; } = "";
+    public string LocationText { get; set; } = "";
+    public string PreviousLocationText { get; set; } = "";
+    public string HighestFileUid { get; set; } = "";
+    public string PolicyOverrideText { get; set; } = "Not specified";
+    public string VolumeLockState { get; set; } = "";
+    public int DirectoryCount { get; set; }
+    public int FileCount { get; set; }
+    public long TotalBytes { get; set; }
+    public SchemaNode? Root { get; set; }
+
+    public string Title => string.IsNullOrWhiteSpace(VolumeName) ? FileName : VolumeName;
+    public string CountText => $"{DirectoryCount:N0} director{(DirectoryCount == 1 ? "y" : "ies")}, " +
+                               $"{FileCount:N0} file{(FileCount == 1 ? "" : "s")}";
+    public string BytesText => FormatBytes(TotalBytes);
+
+    public static string FormatBytes(long bytes)
+    {
+        string[] units = { "B", "KB", "MB", "GB", "TB", "PB" };
+        double value = Math.Max(0, bytes);
+        int unit = 0;
+        while (value >= 1024 && unit < units.Length - 1)
+        {
+            value /= 1024;
+            unit++;
+        }
+        return unit == 0
+            ? $"{bytes:N0} {units[unit]}"
+            : $"{value:0.##} {units[unit]} ({bytes:N0} bytes)";
+    }
+}
+
+/// <summary>One directory or file inside an LTFS index snapshot.</summary>
+public sealed class SchemaNode : INotifyPropertyChanged
+{
+    private bool _expanded;
+
+    public string Name { get; set; } = "";
+    public string Path { get; set; } = "";
+    public string Type { get; set; } = "Directory";
+    public bool IsDirectory { get; set; }
+    public bool ReadOnly { get; set; }
+    public bool OpenForWrite { get; set; }
+    public string FileUid { get; set; } = "";
+    public long? Length { get; set; }
+    public string CreationTime { get; set; } = "";
+    public string ChangeTime { get; set; } = "";
+    public string ModifyTime { get; set; } = "";
+    public string AccessTime { get; set; } = "";
+    public string BackupTime { get; set; } = "";
+    public string FirstLocationText => Extents.Count == 0
+        ? "Not specified"
+        : $"Partition {Extents[0].PartitionDisplay} starting from block {Extents[0].StartBlockDisplay}";
+    public int Depth { get; set; }
+    public List<SchemaNode> Children { get; } = new();
+    public ObservableCollection<SchemaExtent> Extents { get; } = new();
+
+    public bool Expanded
+    {
+        get => _expanded;
+        set
+        {
+            if (_expanded == value) return;
+            _expanded = value;
+            Raise(nameof(Expanded));
+            Raise(nameof(ExpandGlyph));
+        }
+    }
+
+    public bool CanExpand => Children.Count > 0;
+    public string ExpandGlyph => !CanExpand ? "" : Expanded ? "\uE70D" : "\uE76C"; // ChevronDown / ChevronRight
+    public double ExpandButtonOpacity => CanExpand ? 1 : 0;
+    public string IconGlyph => IsDirectory ? "\uE8B7" : "\uE8A5"; // Folder / Document
+    public Thickness RowMargin => new(Math.Min(Depth, 12) * 18, 0, 0, 0);
+    public string LengthText => IsDirectory
+        ? $"{Children.Count:N0} item{(Children.Count == 1 ? "" : "s")}"
+        : Length.HasValue ? SchemaSnapshot.FormatBytes(Length.Value) : "";
+    public string FlagsText
+    {
+        get
+        {
+            var flags = new List<string>();
+            if (ReadOnly) flags.Add("read-only");
+            if (OpenForWrite) flags.Add("open for write");
+            return flags.Count == 0 ? "none" : string.Join(", ", flags);
+        }
+    }
+
+    private void Raise(string name) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+}
+
+/// <summary>Tree row wrapper so WinUI TreeView can bind to lazy nodes safely.</summary>
+public sealed class SchemaTreeRow
+{
+    public SchemaNode Node { get; }
+
+    public SchemaTreeRow(SchemaNode node) => Node = node;
+
+    public string Name => Node.Name;
+    public string IconGlyph => Node.IconGlyph;
+}
+
+/// <summary>One tape extent for a file in an LTFS index snapshot.</summary>
+public sealed class SchemaExtent
+{
+    public string FileOffset { get; set; } = "";
+    public string Partition { get; set; } = "";
+    public string StartBlock { get; set; } = "";
+    public string ByteOffset { get; set; } = "";
+    public string ByteCount { get; set; } = "";
+
+    public string PartitionDisplay => Blank(Partition);
+    public string StartBlockDisplay => Blank(StartBlock);
+    public string LocationText => $"partition {PartitionDisplay}, block {StartBlockDisplay}";
+    public string OffsetText => $"file offset {Blank(FileOffset)}, byte offset {Blank(ByteOffset)}";
+    public string ByteCountText => long.TryParse(ByteCount, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bytes)
+        ? SchemaSnapshot.FormatBytes(bytes)
+        : Blank(ByteCount);
+
+    private static string Blank(string value) => string.IsNullOrWhiteSpace(value) ? "?" : value;
 }
 
 /// <summary>

--- a/gui/MainWindow.xaml.cs
+++ b/gui/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ public sealed partial class MainWindow : Window
     private readonly Settings _settings = Settings.Load();
     private readonly MountManager _mounts = new();
     private List<TapeDrive> _drives = new();
+    private readonly List<Window> _childWindows = new();
     private bool _loadingUi;
     private bool _polling;
     private bool _utilityRunning;
@@ -948,7 +949,17 @@ public sealed partial class MainWindow : Window
         if ((sender as FrameworkElement)?.DataContext is not SchemaItem item) return;
         try
         {
-            Process.Start(new ProcessStartInfo(item.Path) { UseShellExecute = true });
+            if (!File.Exists(item.Path))
+            {
+                Activity.Note($"open snapshot failed: file no longer exists: {item.Path}", isError: true);
+                RefreshSchemas();
+                return;
+            }
+
+            var viewer = new SchemaViewerWindow(item.Path);
+            _childWindows.Add(viewer);
+            viewer.Closed += (_, _) => _childWindows.Remove(viewer);
+            viewer.Activate();
         }
         catch (Exception ex) { Activity.Note($"open snapshot failed: {ex.Message}", isError: true); }
     }

--- a/gui/SchemaParser.cs
+++ b/gui/SchemaParser.cs
@@ -1,0 +1,152 @@
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace LTOG.Gui;
+
+internal static class SchemaParser
+{
+    public static SchemaSnapshot Parse(FileInfo f)
+    {
+        var doc = XDocument.Load(f.FullName, LoadOptions.None);
+        var root = doc.Root ?? throw new InvalidDataException("Missing LTFS index root element.");
+
+        var snapshot = new SchemaSnapshot
+        {
+            Path = f.FullName,
+            FileName = f.Name,
+            FormatVersion = Attr(root, "version"),
+            Creator = Text(root, "creator"),
+            VolumeUuid = Text(root, "volumeuuid"),
+            GenerationNumber = Text(root, "generationnumber"),
+            UpdatedText = FormatSchemaTime(Text(root, "updatetime")),
+            LocationText = ReadLocation(ElementAny(root, "location")),
+            PreviousLocationText = ReadLocation(ElementAny(root, "previousgenerationlocation")),
+            HighestFileUid = Text(root, "highestfileuid"),
+            PolicyOverrideText = IsTrue(Text(root, "allowpolicyupdate")) ? "Permitted" : "Not permitted",
+            VolumeLockState = Text(root, "volumelockstate"),
+        };
+
+        var rootDir = root.ElementsAny("directory").FirstOrDefault();
+        if (rootDir != null)
+        {
+            snapshot.Root = ReadNode(rootDir, "", 0, snapshot);
+            snapshot.VolumeName = string.IsNullOrWhiteSpace(snapshot.Root.Name)
+                ? "(unlabelled volume)"
+                : snapshot.Root.Name;
+            snapshot.Root.Expanded = true;
+        }
+        else
+        {
+            snapshot.Root = new SchemaNode
+            {
+                Name = "(empty index)",
+                Path = "/",
+                Type = "Directory",
+                IsDirectory = true,
+                Expanded = true,
+            };
+        }
+
+        return snapshot;
+    }
+
+    private static SchemaNode ReadNode(XElement element, string parentPath, int depth, SchemaSnapshot snapshot)
+    {
+        bool isDirectory = element.Name.LocalName == "directory";
+        var node = new SchemaNode
+        {
+            Name = Text(element, "name"),
+            Type = isDirectory ? "Directory" : "File",
+            IsDirectory = isDirectory,
+            ReadOnly = IsTrue(Text(element, "readonly")),
+            OpenForWrite = IsTrue(Text(element, "openforwrite")),
+            FileUid = Text(element, "fileuid"),
+            CreationTime = FormatSchemaTime(Text(element, "creationtime")),
+            ChangeTime = FormatSchemaTime(Text(element, "changetime")),
+            ModifyTime = FormatSchemaTime(Text(element, "modifytime")),
+            AccessTime = FormatSchemaTime(Text(element, "accesstime")),
+            BackupTime = FormatSchemaTime(Text(element, "backuptime")),
+            Depth = depth,
+        };
+
+        if (long.TryParse(Text(element, "length"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var length))
+        {
+            node.Length = length;
+            snapshot.TotalBytes += length;
+        }
+
+        if (string.IsNullOrWhiteSpace(node.Name))
+            node.Name = isDirectory && depth == 0 ? "/" : "(unnamed)";
+        node.Path = CombineSchemaPath(parentPath, node.Name, depth);
+
+        foreach (var extentInfo in element.ElementsAny("extentinfo"))
+        {
+            foreach (var extent in extentInfo.ElementsAny("extent"))
+                node.Extents.Add(ReadExtent(extent));
+        }
+
+        var contents = element.ElementsAny("contents").FirstOrDefault();
+        if (contents != null)
+        {
+            foreach (var child in contents.Elements().Where(e => e.Name.LocalName is "directory" or "file"))
+                node.Children.Add(ReadNode(child, node.Path, depth + 1, snapshot));
+        }
+
+        if (isDirectory) snapshot.DirectoryCount++;
+        else snapshot.FileCount++;
+
+        return node;
+    }
+
+    private static SchemaExtent ReadExtent(XElement element) => new()
+    {
+        FileOffset = Text(element, "fileoffset"),
+        Partition = Text(element, "partition"),
+        StartBlock = Text(element, "startblock"),
+        ByteOffset = Text(element, "byteoffset"),
+        ByteCount = Text(element, "bytecount"),
+    };
+
+    private static string ReadLocation(XElement? element)
+    {
+        if (element == null) return "Not specified";
+        string partition = Text(element, "partition");
+        string block = Text(element, "startblock");
+        return $"Partition {Blank(partition)} starting from block {Blank(block)}";
+    }
+
+    private static string CombineSchemaPath(string parentPath, string name, int depth)
+    {
+        if (depth == 0) return "";
+        string clean = string.IsNullOrWhiteSpace(name) ? "(unnamed)" : name;
+        if (string.IsNullOrWhiteSpace(parentPath))
+            return "\\" + clean;
+        return parentPath.TrimEnd('\\') + "\\" + clean;
+    }
+
+    private static string FormatSchemaTime(string value)
+    {
+        if (DateTimeOffset.TryParse(value, null, DateTimeStyles.AssumeUniversal, out var dt))
+            return dt.UtcDateTime.ToString("yyyy-MM-dd 'at' HH:mm:ss '(UTC)'");
+        return value;
+    }
+
+    private static bool IsTrue(string value) =>
+        value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+        value == "1";
+
+    private static string Text(XElement element, string localName) =>
+        element.ElementsAny(localName).FirstOrDefault()?.Value.Trim() ?? "";
+
+    private static string Attr(XElement element, string localName) =>
+        element.Attributes().FirstOrDefault(a => a.Name.LocalName == localName)?.Value.Trim() ?? "";
+
+    private static IEnumerable<XElement> ElementsAny(this XContainer element, string localName) =>
+        element.Elements().Where(e => e.Name.LocalName == localName);
+
+    private static XElement? ElementAny(XContainer element, string localName) =>
+        element.Elements().FirstOrDefault(e => e.Name.LocalName == localName);
+
+    private static string Blank(string value) => string.IsNullOrWhiteSpace(value) ? "?" : value;
+}

--- a/gui/SchemaViewerWindow.xaml
+++ b/gui/SchemaViewerWindow.xaml
@@ -1,0 +1,164 @@
+<Window
+    x:Class="LTOG.Gui.SchemaViewerWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:LTOG.Gui"
+    Title="LTOG">
+
+    <Grid x:Name="Root" Padding="18" ColumnSpacing="18">
+        <Grid.Resources>
+            <Style x:Key="PanelBorder" TargetType="Border">
+                <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="CornerRadius" Value="4" />
+                <Setter Property="Padding" Value="10" />
+            </Style>
+            <Style x:Key="PropertyLabel" TargetType="TextBlock">
+                <Setter Property="Opacity" Value="0.75" />
+                <Setter Property="Margin" Value="0,0,10,0" />
+            </Style>
+        </Grid.Resources>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="13*" />
+            <ColumnDefinition Width="10*" />
+        </Grid.ColumnDefinitions>
+
+        <Border Style="{StaticResource PanelBorder}" Padding="0">
+            <TreeView x:Name="SchemaTree"
+                      ItemInvoked="SchemaTree_ItemInvoked"
+                      Expanding="SchemaTree_Expanding">
+                <TreeView.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <FontIcon Glyph="{Binding Content.IconGlyph}" FontSize="16" Opacity="0.85" />
+                            <TextBlock Text="{Binding Content.Name}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </TreeView.ItemTemplate>
+            </TreeView>
+        </Border>
+
+        <Grid Grid.Column="1" RowSpacing="14">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Style="{StaticResource PanelBorder}">
+                <StackPanel Spacing="8">
+                    <TextBlock Text="Cartridge properties"
+                               Style="{StaticResource BodyStrongTextBlockStyle}" />
+                    <Grid ColumnSpacing="8" RowSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Text="Volume UUID" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="VolumeUuidText" Grid.Column="1" TextWrapping="Wrap"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="1" Text="Format version" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="FormatVersionText" Grid.Row="1" Grid.Column="1"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="2" Text="Index written by" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="CreatorText" Grid.Row="2" Grid.Column="1" TextWrapping="Wrap"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="3" Text="Index revision" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="GenerationText" Grid.Row="3" Grid.Column="1"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="4" Text="Updated" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="UpdatedText" Grid.Row="4" Grid.Column="1"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="5" Text="Highest file id" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="HighestFileIdText" Grid.Row="5" Grid.Column="1"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="6" Text="Policy override" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="PolicyOverrideText" Grid.Row="6" Grid.Column="1"
+                                   IsTextSelectionEnabled="True" />
+                        <TextBlock Grid.Row="7" Text="Volume lock" Style="{StaticResource PropertyLabel}" />
+                        <TextBlock x:Name="VolumeLockText" Grid.Row="7" Grid.Column="1"
+                                   IsTextSelectionEnabled="True" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Grid Grid.Row="1" ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="SelectedPathBox" IsReadOnly="True" />
+                <Button Grid.Column="1" Content="Copy" MinWidth="76"
+                        Click="CopyPath_Click" />
+            </Grid>
+
+            <Border Grid.Row="2" Style="{StaticResource PanelBorder}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Auto">
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="File properties"
+                                   Style="{StaticResource BodyStrongTextBlockStyle}" />
+                        <Grid ColumnSpacing="8" RowSpacing="10">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <TextBlock Text="Length" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="LengthText" Grid.Column="1" TextWrapping="Wrap"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="1" Text="File ID" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="FileIdText" Grid.Row="1" Grid.Column="1"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="2" Text="Read only" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="ReadOnlyText" Grid.Row="2" Grid.Column="1"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="3" Text="Created" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="CreatedText" Grid.Row="3" Grid.Column="1" TextWrapping="Wrap"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="4" Text="Modified" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="ModifiedText" Grid.Row="4" Grid.Column="1" TextWrapping="Wrap"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="5" Text="Accessed" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="AccessedText" Grid.Row="5" Grid.Column="1" TextWrapping="Wrap"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="6" Text="Backup time" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="BackupText" Grid.Row="6" Grid.Column="1" TextWrapping="Wrap"
+                                       IsTextSelectionEnabled="True" />
+                            <TextBlock Grid.Row="7" Text="Location" Style="{StaticResource PropertyLabel}" />
+                            <TextBlock x:Name="LocationText" Grid.Row="7" Grid.Column="1" TextWrapping="Wrap"
+                                       IsTextSelectionEnabled="True" />
+                        </Grid>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+
+            <Button Grid.Row="3" Content="Close" MinWidth="110"
+                    HorizontalAlignment="Right" Click="Close_Click" />
+        </Grid>
+    </Grid>
+</Window>

--- a/gui/SchemaViewerWindow.xaml.cs
+++ b/gui/SchemaViewerWindow.xaml.cs
@@ -1,0 +1,156 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace LTOG.Gui;
+
+public sealed partial class SchemaViewerWindow : Window
+{
+    private readonly SchemaSnapshot _snapshot;
+    private readonly HashSet<SchemaNode> _expandedOnce = new();
+
+    public SchemaViewerWindow(string schemaPath)
+    {
+        _snapshot = SchemaParser.Parse(new FileInfo(schemaPath));
+
+        InitializeComponent();
+        SystemBackdrop = new MicaBackdrop();
+        AppWindow.Resize(new Windows.Graphics.SizeInt32(1360, 900));
+        Title = $"LTOG: viewing LTFS Index {_snapshot.Path}";
+
+        try
+        {
+            var ico = Path.Combine(AppContext.BaseDirectory, "Assets", "icon.ico");
+            if (File.Exists(ico))
+                AppWindow.SetIcon(ico);
+        }
+        catch { }
+
+        PopulateCartridgeProperties();
+        if (_snapshot.Root != null)
+            SchemaTree.RootNodes.Add(BuildTreeNode(_snapshot.Root, true));
+        ShowNode(_snapshot.Root);
+    }
+
+    private void PopulateCartridgeProperties()
+    {
+        VolumeUuidText.Text = Blank(_snapshot.VolumeUuid);
+        FormatVersionText.Text = Blank(_snapshot.FormatVersion);
+        CreatorText.Text = Blank(_snapshot.Creator);
+        GenerationText.Text = Blank(_snapshot.GenerationNumber);
+        UpdatedText.Text = Blank(_snapshot.UpdatedText);
+        HighestFileIdText.Text = Blank(_snapshot.HighestFileUid);
+        PolicyOverrideText.Text = Blank(_snapshot.PolicyOverrideText);
+        VolumeLockText.Text = Blank(_snapshot.VolumeLockState);
+    }
+
+    private static TreeViewNode BuildTreeNode(SchemaNode node, bool expanded = false)
+    {
+        var treeNode = new TreeViewNode
+        {
+            Content = new SchemaTreeRow(node),
+            IsExpanded = expanded,
+            HasUnrealizedChildren = node.Children.Count > 0,
+        };
+        if (expanded)
+            PopulateTreeNode(treeNode);
+        return treeNode;
+    }
+
+    private void SchemaTree_ItemInvoked(TreeView sender, TreeViewItemInvokedEventArgs args)
+    {
+        if (args.InvokedItem is SchemaTreeRow row)
+        {
+            ShowNode(row.Node);
+            ToggleTreeNode(row.Node);
+        }
+        else if (args.InvokedItem is TreeViewNode treeNode && treeNode.Content is SchemaTreeRow row2)
+        {
+            ShowNode(row2.Node);
+            ToggleTreeNode(row2.Node);
+        }
+    }
+
+    private void ToggleTreeNode(SchemaNode node)
+    {
+        if (node.Children.Count == 0) return;
+        var treeNode = FindTreeNode(SchemaTree.RootNodes, node);
+        if (treeNode == null) return;
+        if (!treeNode.IsExpanded)
+            PopulateTreeNode(treeNode);
+        treeNode.IsExpanded = !treeNode.IsExpanded;
+    }
+
+    private static TreeViewNode? FindTreeNode(IEnumerable<TreeViewNode> nodes, SchemaNode target)
+    {
+        foreach (var treeNode in nodes)
+        {
+            if (treeNode.Content is SchemaTreeRow row && ReferenceEquals(row.Node, target))
+                return treeNode;
+            var child = FindTreeNode(treeNode.Children, target);
+            if (child != null)
+                return child;
+        }
+        return null;
+    }
+
+    private static void PopulateTreeNode(TreeViewNode treeNode)
+    {
+        if (treeNode.Content is not SchemaTreeRow row)
+            return;
+        var node = row.Node;
+        if (!treeNode.HasUnrealizedChildren && treeNode.Children.Count > 0)
+            return;
+        if (treeNode.Children.Count == node.Children.Count &&
+            treeNode.Children.All(child => child.Content is SchemaTreeRow))
+            return;
+
+        treeNode.Children.Clear();
+        foreach (var child in node.Children)
+            treeNode.Children.Add(BuildTreeNode(child));
+        treeNode.HasUnrealizedChildren = false;
+    }
+
+    private void SchemaTree_Expanding(object sender, TreeViewExpandingEventArgs args)
+    {
+        if (args.Node.Content is not SchemaTreeRow row)
+            return;
+        if (!_expandedOnce.Add(row.Node))
+            return;
+        PopulateTreeNode(args.Node);
+    }
+
+    private void ShowNode(SchemaNode? node)
+    {
+        if (node == null)
+        {
+            SelectedPathBox.Text = "";
+            LengthText.Text = FileIdText.Text = ReadOnlyText.Text = CreatedText.Text =
+                ModifiedText.Text = AccessedText.Text = BackupText.Text = LocationText.Text = "";
+            return;
+        }
+
+        SelectedPathBox.Text = string.IsNullOrWhiteSpace(node.Path) ? "\\" : node.Path;
+        LengthText.Text = node.IsDirectory
+            ? $"{node.Children.Count:N0} item{(node.Children.Count == 1 ? "" : "s")}"
+            : node.Length.HasValue ? SchemaSnapshot.FormatBytes(node.Length.Value) : "Not specified";
+        FileIdText.Text = Blank(node.FileUid);
+        ReadOnlyText.Text = node.ReadOnly ? "true" : "false";
+        CreatedText.Text = Blank(node.CreationTime);
+        ModifiedText.Text = Blank(node.ModifyTime);
+        AccessedText.Text = Blank(node.AccessTime);
+        BackupText.Text = Blank(node.BackupTime);
+        LocationText.Text = node.IsDirectory ? "Not specified" : node.FirstLocationText;
+    }
+
+    private void CopyPath_Click(object sender, RoutedEventArgs e)
+    {
+        var package = new Windows.ApplicationModel.DataTransfer.DataPackage();
+        package.SetText(SelectedPathBox.Text);
+        Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
+    }
+
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+
+    private static string Blank(string value) => string.IsNullOrWhiteSpace(value) ? "Not specified" : value;
+}


### PR DESCRIPTION
Opening a captured .schema file from the Indexes page now launches an in-app LTFS index viewer instead of falling back to the Windows file association dialog. The new viewer parses LTFS schema XML, displays cartridge metadata, and provides a navigable tape directory tree with file properties, timestamps, size information, tape extent location details, and path copy support.

The viewer runs in a dedicated window to provide enough space for browsing larger tape structures, with lazy tree population for nested directories.